### PR TITLE
Update TrajectorySequenceBuilder.java (optimization/fix)

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/trajectorysequence/TrajectorySequenceBuilder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/trajectorysequence/TrajectorySequenceBuilder.java
@@ -549,46 +549,54 @@ public class TrajectorySequenceBuilder {
     private List<SequenceSegment> projectGlobalMarkersToLocalSegments(List<TrajectoryMarker> markers, List<SequenceSegment> sequenceSegments) {
         if (sequenceSegments.isEmpty()) return Collections.emptyList();
 
+        markers.sort(Comparator.comparingDouble(TrajectoryMarker::getTime));
+
         double totalSequenceDuration = 0;
         for (SequenceSegment segment : sequenceSegments) {
             totalSequenceDuration += segment.getDuration();
         }
 
+        int segmentIndex = 0;
+        double currentTime = 0;
+
         for (TrajectoryMarker marker : markers) {
             SequenceSegment segment = null;
-            int segmentIndex = 0;
+
+            double markerTime = Math.min(marker.getTime(), totalSequenceDuration);
             double segmentOffsetTime = 0;
 
-            double currentTime = 0;
-            for (int i = 0; i < sequenceSegments.size(); i++) {
-                SequenceSegment seg = sequenceSegments.get(i);
-
-                double markerTime = Math.min(marker.getTime(), totalSequenceDuration);
+            while (segmentIndex < sequenceSegments.size()) {
+                SequenceSegment seg = sequenceSegments.get(segmentIndex);
 
                 if (currentTime + seg.getDuration() >= markerTime) {
                     segment = seg;
-                    segmentIndex = i;
                     segmentOffsetTime = markerTime - currentTime;
-
                     break;
                 } else {
                     currentTime += seg.getDuration();
+                    segmentIndex++;
                 }
+            }
+            if (segmentIndex >= sequenceSegments.size()) {
+                segment = sequenceSegments.get(sequenceSegments.size()-1);
+                segmentOffsetTime = segment.getDuration();
             }
 
             SequenceSegment newSegment = null;
 
             if (segment instanceof WaitSegment) {
-                List<TrajectoryMarker> newMarkers = new ArrayList<>(segment.getMarkers());
+                WaitSegment thisSegment = (WaitSegment) segment;
+                
+                List<TrajectoryMarker> newMarkers = new ArrayList<>(thisSegment.getMarkers());
                 newMarkers.add(new TrajectoryMarker(segmentOffsetTime, marker.getCallback()));
 
-                WaitSegment thisSegment = (WaitSegment) segment;
                 newSegment = new WaitSegment(thisSegment.getStartPose(), thisSegment.getDuration(), newMarkers);
             } else if (segment instanceof TurnSegment) {
-                List<TrajectoryMarker> newMarkers = new ArrayList<>(segment.getMarkers());
+                TurnSegment thisSegment = (TurnSegment) segment;
+                
+                List<TrajectoryMarker> newMarkers = new ArrayList<>(thisSegment.getMarkers());
                 newMarkers.add(new TrajectoryMarker(segmentOffsetTime, marker.getCallback()));
 
-                TurnSegment thisSegment = (TurnSegment) segment;
                 newSegment = new TurnSegment(thisSegment.getStartPose(), thisSegment.getTotalRotation(), thisSegment.getMotionProfile(), newMarkers);
             } else if (segment instanceof TrajectorySegment) {
                 TrajectorySegment thisSegment = (TrajectorySegment) segment;


### PR DESCRIPTION
Changed the "projectGlobalMarkersToLocalSegments" function in TrajectorySequenceBuilder. Now, instead of looping through all segments for every marker, the markers are first sorted by time and then the segmentIndex (initially 0) only needs to be incremented (thanks to monotonicity). Also added support for an edge-case which may be made possible through weird floating-point arithmetic.
